### PR TITLE
Update ConfigurationUtility.php

### DIFF
--- a/Classes/Utility/ConfigurationUtility.php
+++ b/Classes/Utility/ConfigurationUtility.php
@@ -50,8 +50,7 @@ class ConfigurationUtility
 
     private static function loadConfigurationFromYaml(string $fileName, int $page): array
     {
-        $yamlParser = new Yaml();
-        $configuration = $yamlParser->parse(file_get_contents($fileName));
+        $configuration = Yaml::parse(file_get_contents($fileName));
 
         $configurationArray = [];
         $isFirst = true;


### PR DESCRIPTION
Yaml::parse is a static method and should be called as such.